### PR TITLE
Improve dropdown styling and text contrast in practice problems UI

### DIFF
--- a/packages/alea-frontend/components/ProblemList.tsx
+++ b/packages/alea-frontend/components/ProblemList.tsx
@@ -188,7 +188,7 @@ const ProblemList: FC<ProblemListProps> = ({ courseSections, courseId }) => {
       >
         <Typography
           variant="body1"
-          sx={{ color: 'secondary.main', fontStyle: 'italic', mb: 3, lineHeight: 1.6 }}
+          sx={{ color: 'text.primary', fontStyle: 'italic', mb: 3, lineHeight: 1.6 }}
         >
           Old exams are great practice resources, but since exam styles evolve, recent exams are
           better models, and any course topic even if not asked before can still appear in upcoming

--- a/packages/alea-frontend/pages/exam-problems.tsx
+++ b/packages/alea-frontend/pages/exam-problems.tsx
@@ -19,7 +19,6 @@ import {
 
 import MainLayout from '../layouts/MainLayout';
 import { contentFragment } from '@flexiformal/ftml-backend';
-import { red } from '@mui/material/colors';
 
 async function buildFTMLProblem(problemUri: string): Promise<FTMLProblemWithSolution> {
   const fragmentResponse: any[] = await contentFragment({ uri: problemUri });
@@ -59,19 +58,14 @@ const ExamProblemsPage = () => {
     if (!examUri) return;
 
     const fetchData = async () => {
-        console.log("start fetch1234");
       setLoading(true);
       try {
         const decodedUri = decodeURIComponent(examUri);
 
-        console.log("start fetch");
-
         const meta = await getExamMetadataByUri(decodedUri);
-        console.log('Meta done');
         setExamMeta(meta);
 
         const uris = await getProblemsForExam(decodedUri);
-        console.log('Problems URIs:', uris);
 
         if (targetProblemId) {
           const idx = uris.indexOf(decodeURIComponent(targetProblemId));
@@ -79,7 +73,6 @@ const ExamProblemsPage = () => {
         }
 
         const examProblems = await buildExamProblems(uris);
-        console.log('Problems URIs:', uris);
         setProblems(examProblems);
       } catch (error) {
         console.error('Error loading exam data:', error);
@@ -102,7 +95,6 @@ const ExamProblemsPage = () => {
     return formatExamLabelFullFromUri(examUri, examMeta);
   }, [examUri, examMeta]);
 
-  console.log({loading});
   if (loading) {
     return (
       <MainLayout title="Exam">
@@ -146,8 +138,6 @@ const ExamProblemsPage = () => {
             </Tooltip>
           )}
         </Box>
-
-        <Box bgcolor={red} height={"20px"}>abx</Box>
 
         <GradingContext.Provider
           value={{

--- a/packages/alea-frontend/pages/exam-problems.tsx
+++ b/packages/alea-frontend/pages/exam-problems.tsx
@@ -19,6 +19,7 @@ import {
 
 import MainLayout from '../layouts/MainLayout';
 import { contentFragment } from '@flexiformal/ftml-backend';
+import { red } from '@mui/material/colors';
 
 async function buildFTMLProblem(problemUri: string): Promise<FTMLProblemWithSolution> {
   const fragmentResponse: any[] = await contentFragment({ uri: problemUri });
@@ -58,14 +59,19 @@ const ExamProblemsPage = () => {
     if (!examUri) return;
 
     const fetchData = async () => {
+        console.log("start fetch1234");
       setLoading(true);
       try {
         const decodedUri = decodeURIComponent(examUri);
 
+        console.log("start fetch");
+
         const meta = await getExamMetadataByUri(decodedUri);
+        console.log('Meta done');
         setExamMeta(meta);
 
         const uris = await getProblemsForExam(decodedUri);
+        console.log('Problems URIs:', uris);
 
         if (targetProblemId) {
           const idx = uris.indexOf(decodeURIComponent(targetProblemId));
@@ -73,10 +79,12 @@ const ExamProblemsPage = () => {
         }
 
         const examProblems = await buildExamProblems(uris);
+        console.log('Problems URIs:', uris);
         setProblems(examProblems);
       } catch (error) {
         console.error('Error loading exam data:', error);
       } finally {
+        console.log('Finished loading exam data');
         setLoading(false);
       }
     };
@@ -94,6 +102,7 @@ const ExamProblemsPage = () => {
     return formatExamLabelFullFromUri(examUri, examMeta);
   }, [examUri, examMeta]);
 
+  console.log({loading});
   if (loading) {
     return (
       <MainLayout title="Exam">
@@ -137,6 +146,8 @@ const ExamProblemsPage = () => {
             </Tooltip>
           )}
         </Box>
+
+        <Box bgcolor={red} height={"20px"}>abx</Box>
 
         <GradingContext.Provider
           value={{

--- a/packages/alea-frontend/pages/quiz-problems.tsx
+++ b/packages/alea-frontend/pages/quiz-problems.tsx
@@ -47,6 +47,7 @@ async function buildQuizProblems(
 const QuizProblemsPage = () => {
   const router = useRouter();
   const quizUri = router.query.quizUri as string | undefined;
+  const courseId = router.query.courseId as string | undefined;
   const targetProblemId = router.query.problemId as string | undefined;
 
   const [quizMeta, setQuizMeta] = useState<any>(null);
@@ -86,13 +87,13 @@ const QuizProblemsPage = () => {
 
   const quizLabelShort = useMemo(() => {
     if (!quizUri || !quizMeta) return '';
-    return formatQuizLabelShortFromUri(quizUri, quizMeta);
-  }, [quizUri, quizMeta]);
+    return formatQuizLabelShortFromUri(quizUri, quizMeta, courseId ?? quizMeta?.courseId);
+  }, [quizUri, quizMeta, courseId]);
 
   const quizLabelFull = useMemo(() => {
     if (!quizUri || !quizMeta) return '';
-    return formatQuizLabelFullFromUri(quizUri, quizMeta);
-  }, [quizUri, quizMeta]);
+    return formatQuizLabelFullFromUri(quizUri, quizMeta, courseId ?? quizMeta?.courseId);
+  }, [quizUri, quizMeta, courseId]);
 
   if (loading) {
     return (

--- a/packages/alea-frontend/theme/components.ts
+++ b/packages/alea-frontend/theme/components.ts
@@ -97,7 +97,7 @@ const components: Components = {
         const isDark = theme.palette.mode === 'dark';
 
         return {
-          backgroundColor: theme.palette.background.paper,
+          backgroundColor: theme.palette.background.default,
           borderRadius: 10,
 
           '&:hover .MuiOutlinedInput-notchedOutline': {
@@ -121,98 +121,96 @@ const components: Components = {
       },
     },
   },
-MuiTextField: {
-  defaultProps: {
-    variant: 'outlined',
-  },
-  styleOverrides: {
-    root: ({ theme }:{theme:any}) => {
-      const isDark = theme.palette.mode === 'dark';
+  MuiTextField: {
+    defaultProps: {
+      variant: 'outlined',
+    },
+    styleOverrides: {
+      root: ({ theme }: { theme: any }) => {
+        const isDark = theme.palette.mode === 'dark';
 
-      return {
-        '& .MuiOutlinedInput-root': {
+        return {
+          '& .MuiOutlinedInput-root': {
+            borderRadius: 10,
+            backgroundColor: theme.palette.background.default,
+
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: isDark ? theme.palette.primary.main : theme.palette.divider,
+            },
+
+            '&:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: isDark ? theme.palette.primary.light : theme.palette.primary.main,
+            },
+
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: theme.palette.primary.main,
+            },
+          },
+        };
+      },
+    },
+  },
+
+  MuiInputLabel: {
+    styleOverrides: {
+      root: ({ theme }: { theme: any }) => ({
+        color: theme.palette.text.primary,
+
+        '&.Mui-focused': {
+          color: theme.palette.text.primary.main,
+        },
+      }),
+    },
+  },
+
+  MuiSelect: {
+    styleOverrides: {
+      select: ({ theme }: { theme: any }) => ({
+        color: theme.palette.text.primary,
+      }),
+
+      icon: ({ theme }: { theme: any }) => ({
+        color: theme.palette.text.secondary,
+      }),
+    },
+  },
+
+  MuiAutocomplete: {
+    styleOverrides: {
+      paper: ({ theme }: { theme: any }) => ({
+        borderRadius: 10,
+        backgroundColor: theme.palette.background.paper,
+        color: theme.palette.text.primary,
+        borderColor: theme.palette.primary.main,
+      }),
+      inputRoot: ({ theme }: { theme: any }) => {
+        const isDark = theme.palette.mode === 'dark';
+
+        return {
           borderRadius: 10,
-          backgroundColor: theme.palette.background.paper,
 
           '& .MuiOutlinedInput-notchedOutline': {
-            borderColor: isDark
-              ? theme.palette.primary.main:theme.palette.divider,
-          },
-
-          '&:hover .MuiOutlinedInput-notchedOutline': {
-            borderColor: isDark
-              ? theme.palette.primary.light
-              : theme.palette.primary.main,
+            borderColor: isDark ? theme.palette.primary.main : theme.palette.divider,
           },
 
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
             borderColor: theme.palette.primary.main,
+            borderWidth: 1.5,
           },
+        };
+      },
+
+      option: ({ theme }: { theme: any }) => ({
+        '&[aria-selected="true"]': {
+          backgroundColor: theme.palette.action.selected,
         },
-      };
+
+        '&.Mui-focused': {
+          backgroundColor: theme.palette.action.hover,
+        },
+      }),
     },
   },
-},
-
-  MuiInputLabel: {
-  styleOverrides: {
-    root: ({ theme }:{theme:any}) => ({
-      color: theme.palette.text.secondary,
-
-      '&.Mui-focused': {
-        color: theme.palette.text.primary,
-      },
-    }),
-  },
-},
-
-MuiSelect: {
-  styleOverrides: {
-    select: ({ theme }:{theme:any}) => ({
-      color: theme.palette.text.primary,
-    }),
-
-    icon: ({ theme }:{theme:any}) => ({
-      color: theme.palette.text.secondary,
-    }),
-  },
-},
-
-MuiAutocomplete: {
-  styleOverrides: {
-    paper: ({ theme }:{theme:any}) => ({
-      borderRadius: 10,
-      backgroundColor: theme.palette.background.paper,
-      color: theme.palette.text.primary,
-      borderColor: theme.palette.primary.main,
-    }),
-    inputRoot: ({ theme }:{theme:any}) => {
-            const isDark = theme.palette.mode === 'dark';
-
-      return({
-      borderRadius: 10,
-
-      '& .MuiOutlinedInput-notchedOutline': {
-        borderColor: isDark?theme.palette.primary.main:theme.palette.divider,
-      },
-
-      '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-        borderColor: theme.palette.primary.main,
-        borderWidth: 1.5,
-      },
-    })},
-
-    option: ({ theme }:{theme:any}) => ({
-      '&[aria-selected="true"]': {
-        backgroundColor: theme.palette.action.selected,
-      },
-
-      '&.Mui-focused': {
-        backgroundColor: theme.palette.action.hover,
-      },
-    }),
-  },
-},
 
   MuiDialog: {
     styleOverrides: {

--- a/packages/stex-react-renderer/src/lib/ExamSelect.tsx
+++ b/packages/stex-react-renderer/src/lib/ExamSelect.tsx
@@ -53,7 +53,7 @@ export function ExamSelect({
           return (
             <MenuItem key={exam.uri} value={exam.uri}>
               <Tooltip title={fullLabel} placement="right" arrow>
-                <Typography noWrap sx={{ maxWidth: 300 }}>
+                <Typography variant="body2" noWrap sx={{ maxWidth: 300 }}>
                   {dropdownLabel}
                 </Typography>
               </Tooltip>

--- a/spec/src/lib/flams.ts
+++ b/spec/src/lib/flams.ts
@@ -529,11 +529,23 @@ export function getQuizMetaFromQuizUri(
     number?: string;
     date?: string;
     courseId?: string;
-  }
+  },
+  courseId?: string
 ): QuizMeta {
   const decoded = decodeURIComponent(quizUri);
 
-  const courseAcronym = quiz?.courseId?.toUpperCase() ?? 'UNKNOWN';
+  let courseAcronym = 'UNKNOWN';
+
+  if (courseId) {
+    courseAcronym = courseId.toUpperCase();
+  } else if (quiz?.courseId) {
+    courseAcronym = quiz.courseId.toUpperCase();
+  } else {
+    const match = decoded.match(/courses\/[^/]+\/([^/]+)/);
+    if (match && match[1]) {
+      courseAcronym = match[1].toUpperCase();
+    }
+  }
 
   const rawTerm = quiz?.term ?? '';
   const formattedTerm = rawTerm.replace(/([A-Z]+)(\d{2})(\d{2})/, '$1 $2/$3');
@@ -550,14 +562,14 @@ export function getQuizMetaFromQuizUri(
   };
 }
 
-export function formatQuizLabelShortFromUri(quizUri: string, quiz?: any) {
-  const meta = getQuizMetaFromQuizUri(quizUri, quiz);
+export function formatQuizLabelShortFromUri(quizUri: string, quiz?: any, courseId?: string) {
+  const meta = getQuizMetaFromQuizUri(quizUri, quiz, courseId);
 
   return [meta.courseAcronym, meta.quizNumber, meta.formattedTerm].filter(Boolean).join(' ');
 }
 
-export function formatQuizLabelFullFromUri(quizUri: string, quiz?: any) {
-  const meta = getQuizMetaFromQuizUri(quizUri, quiz);
+export function formatQuizLabelFullFromUri(quizUri: string, quiz?: any, courseId?: string) {
+  const meta = getQuizMetaFromQuizUri(quizUri, quiz, courseId);
 
   return [
     meta.courseAcronym,


### PR DESCRIPTION
This PR fixes UI issues in the practice problems section, especially related to dropdown styling and text contrast in both light and dark modes.

Fixed incorrect theme usage
Removed manual color overrides and relied on MUI theme defaults
Improved dropdown label visibility (Select Exam / Select Quiz)
Fixed text contrast issues in dark mode for helper paragraph
Ensured consistent usage of `text.primary` for readable content
Cleaned up unnecessary overrides in components